### PR TITLE
README run-mojo direct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See also
 
 #### Usage
 
-Documentation: http://os72.github.io/protoc-jar-maven-plugin/
+Documentation: see http://os72.github.io/protoc-jar-maven-plugin/, particular [run-mojo](http://os72.github.io/protoc-jar-maven-plugin/run-mojo.html).
 
 Sample usage - compile in main cycle into `target/generated-sources`, add folder to pom:
 ```xml


### PR DESCRIPTION
It is easy to overlook run-mojo page, as it is not in left menu.

ref https://github.com/os72/protoc-jar-maven-plugin/issues/20#issuecomment-259754103