### PR TITLE
Include maven types

### DIFF
--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -446,7 +446,6 @@ public class ProtocJarMojo extends AbstractMojo
 				getLog().error("Unexpected error", e);
 			}finally{
 				close(zis);
-				close(zis);
 			}
 		}
 	}

--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -18,15 +18,10 @@
  */
 package com.github.os72.protocjar.maven;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
+import java.io.*;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -86,6 +81,15 @@ public class ProtocJarMojo extends AbstractMojo
 	 * @parameter property="includeStdTypes" default-value="false"
 	 */
 	private boolean includeStdTypes;
+
+	/**
+	 * Specifies whether to extract .proto files from Maven dependencies and add them to the protoc import path.
+	 * Options: "none" (do not extract and proto files), "referenced" (extracts proto files only from directly referenced dependencies),
+	 * "transitive" (extracts proto files from all referenced and transitive dependencies)
+	 *
+	 * @parameter property="includeMavenTypes" default-value="none"
+	 */
+	private String includeMavenTypes;
 
 	/**
 	 * Specifies whether to add the source .proto files found in inputDirectories/includeDirectories to the generated jar file.
@@ -321,7 +325,8 @@ public class ProtocJarMojo extends AbstractMojo
 		}
 		
 		File stdTypeDir = null;
-		if ((protocCommand == null && protocArtifact == null) || includeStdTypes) {
+		File mavenTypeDir = null;
+		if ((protocCommand == null && protocArtifact == null) || includeStdTypes || includeMavenTypes()) {
 			if (protocVersion == null || protocVersion.length() < 1) protocVersion = ProtocVersion.PROTOC_VERSION.mVersion;
 			getLog().info("Protoc version: " + protocVersion);
 			
@@ -340,10 +345,14 @@ public class ProtocJarMojo extends AbstractMojo
 						protocCommand = protocFile.getAbsolutePath();
 					}
 					stdTypeDir = new File(protocFile.getParentFile().getParentFile(), "include");
+					mavenTypeDir = new File(protocFile.getParentFile().getParentFile(), "maven-include");
 				}
-				else if (includeStdTypes) {
+				else if (includeStdTypes || includeMavenTypes()) {
 					File tmpDir = Protoc.extractStdTypes(ProtocVersion.getVersion("-v"+protocVersion), null);
-					stdTypeDir = new File(tmpDir, "include");
+					if(includeStdTypes)
+						stdTypeDir = new File(tmpDir, "include");
+					if (includeMavenTypes())
+						mavenTypeDir = new File(tmpDir, "maven-include");
 				}
 			}
 			catch (IOException e) {
@@ -378,17 +387,14 @@ public class ProtocJarMojo extends AbstractMojo
 				projectHelper.addResource(project, input.getAbsolutePath(), incs, excs);			
 			}
 		}
-		
+
 		if (includeStdTypes) {
-			if (includeDirectories != null && includeDirectories.length > 0) {
-				List<File> includeDirList = new ArrayList<File>();
-				includeDirList.add(stdTypeDir);
-				includeDirList.addAll(Arrays.asList(includeDirectories));
-				includeDirectories = includeDirList.toArray(new File[0]);
-			}
-			else {
-				includeDirectories = new File[] { stdTypeDir };
-			}
+			updateIncludeDirectories(stdTypeDir);
+		}
+
+		if (includeMavenTypes()) {
+			extractProtoFromDependencies(mavenTypeDir);
+			updateIncludeDirectories(mavenTypeDir);
 		}
 		
 		if (includeDirectories != null && includeDirectories.length > 0) {
@@ -407,6 +413,85 @@ public class ProtocJarMojo extends AbstractMojo
 		for (OutputTarget target : outputTargets) getLog().info("    " + target);
 		for (OutputTarget target : outputTargets) preprocessTarget(target);
 		for (OutputTarget target : outputTargets) processTarget(target);
+	}
+
+	private boolean includeMavenTypes(){
+		return includeMavenTypes.equalsIgnoreCase("dependency") || includeMavenTypes.equalsIgnoreCase("transitive");
+	}
+
+	@SuppressWarnings("unchecked")
+	private Set<Artifact> getArtifactsForProtoExtraction(){
+		if(includeMavenTypes.equalsIgnoreCase("dependency"))
+			return project.getDependencyArtifacts();
+		else if(includeMavenTypes.equalsIgnoreCase("transitive"))
+			return project.getArtifacts();
+		return new HashSet<Artifact>();
+	}
+
+	private void extractProtoFromDependencies(File mavenTypeDir){
+		for (Artifact artifact : getArtifactsForProtoExtraction()) {
+			ZipInputStream zis = null;
+			try {
+				zis = new ZipInputStream(new FileInputStream(artifact.getFile()));
+				ZipEntry ze;
+				while ((ze = zis.getNextEntry()) != null) {
+					if (ze.isDirectory() || !ze.getName().toLowerCase().contains(extension))
+						continue;
+					writeProtoFile(mavenTypeDir, zis, ze);
+					zis.closeEntry();
+				}
+			} catch (IOException e) {
+				getLog().error("Error extrating proto files from artifact: " + artifact.getArtifactId(), e);
+			} catch (Throwable e) {
+				getLog().error("Unexpected error", e);
+			}finally{
+				close(zis);
+				close(zis);
+			}
+		}
+	}
+
+	private void writeProtoFile(File mavenTypeDir, ZipInputStream zis, ZipEntry proto){
+		getLog().info("Including proto file " + proto.getName());
+		File protoOut = new File(mavenTypeDir + File.separator + proto.getName());
+		new File(protoOut.getParent()).mkdirs();
+
+		byte[] buffer = new byte[1024];
+		FileOutputStream fos = null;
+		try{
+			fos = new FileOutputStream(protoOut);
+			int length;
+			while ((length = zis.read(buffer)) > 0) {
+				fos.write(buffer, 0, length);
+			}
+			protoOut.deleteOnExit();
+		}catch(IOException e){
+			getLog().error("Error writing proto file " + proto.getName());
+		}finally{
+			close(fos);
+		}
+	}
+
+	private void close(Closeable c){
+		if (c == null)
+			return;
+		try{
+			c.close();
+		}catch (IOException e){
+			getLog().warn("Error closing input or output stream", e);
+		}
+	}
+
+	private void updateIncludeDirectories(File additionalIncludes){
+		if (includeDirectories != null && includeDirectories.length > 0) {
+			List<File> includeDirList = new ArrayList<File>();
+			includeDirList.add(additionalIncludes);
+			includeDirList.addAll(Arrays.asList(includeDirectories));
+			includeDirectories = includeDirList.toArray(new File[0]);
+		}
+		else {
+			includeDirectories = new File[] { additionalIncludes };
+		}
 	}
 
 	private void preprocessTarget(OutputTarget target) throws MojoExecutionException {


### PR DESCRIPTION
Added "includeMavenTypes" parameter to allow importing proto files from dependency jars (Issue #19 ). 
The allowed values for the "includeMavenTypes" parameter are:

- "none": Do not attempt to extract and proto files from any dependencies. (default)
- "dependency": Attempt to extract proto files from direct dependencies only.
- "transitive": Attempt to extract proto files from all dependencies in the dependency hierarchy. 

