### PR TITLE
Added a null check

### DIFF
--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -451,6 +451,7 @@ public class ProtocJarMojo extends AbstractMojo
 		for (Artifact artifact : getArtifactsForProtoExtraction()) {
 			ZipInputStream zis = null;
 			try {
+				if(artifact.getFile()==null)continue;
 				zis = new ZipInputStream(new FileInputStream(artifact.getFile()));
 				ZipEntry ze;
 				while ((ze = zis.getNextEntry()) != null) {


### PR DESCRIPTION
I found that if a project has any dependencies is in the test scope the Artifact::getFile method returns null. I added a check to avoid trying to open a ZipInputStream in this case. Everything else worked as I would expect. 
Thanks