### PR TITLE
add useInputDirAsWorkingDir flag

### DIFF
--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -249,3 +249,28 @@ protoc-jar-maven-plugin
 	</executions>
 </plugin>
 +---+
+
+  \
+  Sample usage - compile in main cycle into target/generated-sources, use src/main/protobuf as working directory for protoc execution
+
++---+
+<plugin>
+	<groupId>com.github.os72</groupId>
+	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<version>3.6.0.1</version>
+	<executions>
+		<execution>
+			<phase>generate-sources</phase>
+			<goals>
+				<goal>run</goal>
+			</goals>
+			<configuration>
+				<inputDirectories>
+					<include>src/main/protobuf</include>
+				</inputDirectories>
+				<useInputDirectoryAsWorkingDir>true</useInputDirectoryAsWorkingDir>
+			</configuration>
+		</execution>
+	</executions>
+</plugin>
++---+


### PR DESCRIPTION
Currently the single files are processed inside their parent folders.
I've got a usecase in which the files are inside directories but reference relative to the input directory like following illustration:
- src
  - main
    - protobuf
      - module_1
        - file1.proto (imports "module_2/file2.proto")
      - module_2
        - file2.proto

The execution fails because "module_2/file2.proto" can't be found inside module_1.
This pull requests adds a flag called useInputDirAsWorkDir, to address this issue.
If it is set to true, the working directory for every protoc execution is the related input directory.
No breaking change is done due to the fact, that the default value is false.