### PR TITLE
Compile Maven types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
   <url>https://github.com/os72/protoc-jar-maven-plugin</url>
   <description>Protocol Buffers codegen plugin - based on protoc-jar executable JAR</description>
 
+  <properties>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
+
   <parent>
 	<groupId>org.sonatype.oss</groupId>
 	<artifactId>oss-parent</artifactId>
@@ -87,15 +92,6 @@
 
   <build>
 	<plugins>
-		<plugin>
-		  <groupId>org.apache.maven.plugins</groupId>
-		  <artifactId>maven-compiler-plugin</artifactId>
-		  <version>3.0</version>
-		  <configuration>
-			<source>1.5</source>
-			<target>1.5</target>
-		  </configuration>
-		</plugin>
 		<plugin>
 		  <groupId>org.apache.maven.plugins</groupId>
 		  <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.os72</groupId>
   <artifactId>protoc-jar-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>3.6.0.2</version>
+  <version>3.6.0.3-SNAPSHOT</version>
   <name>protoc-jar-maven-plugin</name>
   <url>https://github.com/os72/protoc-jar-maven-plugin</url>
   <description>Protocol Buffers codegen plugin - based on protoc-jar executable JAR</description>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,18 @@
 	</dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>java8-doclint-disabled</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
+
   <build>
 	<plugins>
 		<plugin>
@@ -143,6 +155,9 @@
 				<goals>
 				 <goal>jar</goal>
 				</goals>
+				<configuration>
+					<additionalparam>${javadoc.opts}</additionalparam>
+				</configuration>
 			</execution>
 		  </executions>
 		</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 	  <version>2.2</version>
 	</dependency>
 
-    <!-- test -->
+	<!-- test -->
 	<dependency>
 	  <groupId>junit</groupId>
 	  <artifactId>junit</artifactId>
@@ -91,15 +91,15 @@
   </dependencies>
 
   <profiles>
-    <profile>
-      <id>java8-doclint-disabled</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <javadoc.opts>-Xdoclint:none</javadoc.opts>
-      </properties>
-    </profile>
+	<profile>
+	  <id>java8-doclint-disabled</id>
+	  <activation>
+		<jdk>[1.8,)</jdk>
+	  </activation>
+	  <properties>
+		<javadoc.opts>-Xdoclint:none</javadoc.opts>
+	  </properties>
+	</profile>
   </profiles>
 
   <build>

--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -105,6 +105,15 @@ public class ProtocJarMojo extends AbstractMojo
 	private String includeMavenTypes;
 
 	/**
+	 * Specifies whether to compile .proto files from Maven dependencies.
+	 * Options: "none" (do not extract any proto files), "direct" (compile only direct dependencies),
+	 * "transitive" (compile direct and transitive dependencies).
+	 *
+	 * @parameter property="compileMavenTypes" default-value="none"
+	 */
+	private String compileMavenTypes;
+
+	/**
 	 * Specifies whether to add the source .proto files found in inputDirectories/includeDirectories to the generated jar file.
 	 * Options: "all" (add all), "inputs" (add only from inputDirectories), "none" (default: "none")
 	 * 
@@ -376,19 +385,29 @@ public class ProtocJarMojo extends AbstractMojo
 			}
 		}
 		getLog().info("Protoc command: " + protocCommand);
-		
+
+		File tmpDir;
+		try {
+			tmpDir = File.createTempFile("protocjar", "");
+		} catch (IOException e) {
+			throw new MojoExecutionException("Error creating temporary directory", e);
+		}
+		tmpDir.delete();
+		tmpDir.mkdirs();
+		tmpDir.deleteOnExit();
+
 		// extract additional include types
 		if (includeStdTypes || hasIncludeMavenTypes()) {
 			try {
-				File tmpDir = File.createTempFile("protocjar", "");
-				tmpDir.delete(); tmpDir.mkdirs();
-				tmpDir.deleteOnExit();
 				File extraTypeDir = new File(tmpDir, "include");
 				extraTypeDir.mkdir();
 				getLog().info("Additional include types: " + extraTypeDir);
 				updateIncludeDirectories(extraTypeDir);
 				if (includeStdTypes) Protoc.extractStdTypes(ProtocVersion.getVersion("-v"+protocVersion), tmpDir); // yes, tmpDir
-				if (hasIncludeMavenTypes()) extractProtosFromDependencies(extraTypeDir);
+				if (hasIncludeMavenTypes()) {
+					boolean transitive = includeMavenTypes.equalsIgnoreCase("transitive");
+					extractProtosFromDependencies(extraTypeDir, transitive);
+				}
 				deleteOnExitRecursive(extraTypeDir);
 			}
 			catch (IOException e) {
@@ -400,6 +419,27 @@ public class ProtocJarMojo extends AbstractMojo
 			File inputDir = new File(project.getBasedir().getAbsolutePath() + DEFAULT_INPUT_DIR);
 			inputDirectories = new File[] { inputDir };
 		}
+
+		if (hasCompileMavenTypes()) {
+			getLog().info("Adding .proto files from Maven dependencies: " + compileMavenTypes);
+
+			File mavenTypesCompilesDir = new File(tmpDir, "mvncompile");
+			mavenTypesCompilesDir.mkdir();
+			getLog().info("Maven dependencies types compile sources: " + mavenTypesCompilesDir);
+
+			try {
+				boolean transitive = compileMavenTypes.equalsIgnoreCase("transitive");
+				extractProtosFromDependencies(mavenTypesCompilesDir, transitive);
+			} catch (IOException e) {
+				throw new MojoExecutionException("Error extracting types from maven dependecies", e);
+			}
+
+			deleteOnExitRecursive(mavenTypesCompilesDir);
+
+			inputDirectories = Arrays.copyOf(inputDirectories, inputDirectories.length + 1);
+			inputDirectories[inputDirectories.length - 1] = mavenTypesCompilesDir;
+		}
+
 		getLog().info("Input directories:");
 		for (File input : inputDirectories) {
 			getLog().info("    " + input);
@@ -444,15 +484,20 @@ public class ProtocJarMojo extends AbstractMojo
 		return includeMavenTypes.equalsIgnoreCase("direct") || includeMavenTypes.equalsIgnoreCase("transitive");
 	}
 
-	@SuppressWarnings("unchecked")
-	private Set<Artifact> getArtifactsForProtoExtraction() {
-		if (includeMavenTypes.equalsIgnoreCase("direct")) return project.getDependencyArtifacts();
-		else if (includeMavenTypes.equalsIgnoreCase("transitive")) return project.getArtifacts();
-		return new HashSet<Artifact>();
+	private boolean hasCompileMavenTypes() {
+		return compileMavenTypes.equalsIgnoreCase("direct") || compileMavenTypes.equalsIgnoreCase("transitive");
 	}
 
-	private void extractProtosFromDependencies(File dir) throws IOException {
-		for (Artifact artifact : getArtifactsForProtoExtraction()) {
+	@SuppressWarnings("unchecked")
+    private Set<Artifact> getArtifactsForProtoExtraction(boolean transitive) {
+        if (transitive) {
+            return project.getArtifacts();
+        }
+        return project.getDependencyArtifacts();
+    }
+
+	private void extractProtosFromDependencies(File dir, boolean transitive) throws IOException {
+		for (Artifact artifact : getArtifactsForProtoExtraction(transitive)) {
 			if (artifact.getFile() == null) continue;
 			ZipInputStream zis = null;
 			try {

--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -66,7 +66,7 @@ public class ProtocJarMojo extends AbstractMojo
 {
 	private static final String DEFAULT_INPUT_DIR = "/src/main/protobuf/".replace('/', File.separatorChar);
 
-    /**
+	/**
 	 * Specifies the protoc version (default: latest version).
 	 * 
 	 * @parameter property="protocVersion"
@@ -203,7 +203,7 @@ public class ProtocJarMojo extends AbstractMojo
 	 * Ignored when {@code <outputTargets>} is given
 	 *
 	 * @parameter property="outputOptions"
-     */
+	 */
 	private String outputOptions;
 
 	/**
@@ -296,11 +296,11 @@ public class ProtocJarMojo extends AbstractMojo
 	/** @component */
 	private ArtifactResolver artifactResolver;
 	/** @component */
-    protected MavenProjectHelper projectHelper;
+	protected MavenProjectHelper projectHelper;
 
 	private File tempRoot = null;
 
-    public void execute() throws MojoExecutionException {
+	public void execute() throws MojoExecutionException {
 		if (project.getPackaging() != null && "pom".equals(project.getPackaging().toLowerCase())) {
 			getLog().info("Skipping 'pom' packaged project");
 			return;
@@ -489,12 +489,12 @@ public class ProtocJarMojo extends AbstractMojo
 	}
 
 	@SuppressWarnings("unchecked")
-    private Set<Artifact> getArtifactsForProtoExtraction(boolean transitive) {
-        if (transitive) {
-            return project.getArtifacts();
-        }
-        return project.getDependencyArtifacts();
-    }
+	private Set<Artifact> getArtifactsForProtoExtraction(boolean transitive) {
+		if (transitive) {
+			return project.getArtifacts();
+		}
+		return project.getDependencyArtifacts();
+	}
 
 	private void extractProtosFromDependencies(File dir, boolean transitive) throws IOException {
 		for (Artifact artifact : getArtifactsForProtoExtraction(transitive)) {

--- a/src/test/java/com/github/os72/protocjar/maven/MojoMvnCompileTest.java
+++ b/src/test/java/com/github/os72/protocjar/maven/MojoMvnCompileTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 protoc-jar developers
+ * 
+ * Incorporates code derived from https://github.com/igor-petruk/protobuf-maven-plugin
+ * Copyright 2012, by Yet another Protobuf Maven Plugin Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.os72.protocjar.maven;
+
+import com.github.os72.protocjar.ProtocVersion;
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.2.3"})
+public class MojoMvnCompileTest
+{
+	@Rule
+	public final TestResources resources = new TestResources();
+	public final MavenRuntime maven;
+
+	public MojoMvnCompileTest(MavenRuntimeBuilder mavenBuilder) throws Exception {
+		this.maven = mavenBuilder.withCliOptions("-B", "-U", "-e").build();
+	}
+
+	@Test
+	public void testImport() throws Exception {
+		File basedir = resources.getBasedir("mvn-compile-test");
+		maven.forProject(basedir)
+			.withCliOption("-Dprotobuf.version=" + ProtocVersion.PROTOC_VERSION)
+			.execute("verify")
+			.assertErrorFreeLog();
+	}
+}

--- a/src/test/projects/basic-test/pom.xml
+++ b/src/test/projects/basic-test/pom.xml
@@ -23,6 +23,8 @@
 
   <properties>
 	<protobuf.version>3.6.0</protobuf.version>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/src/test/projects/grpc-test/pom.xml
+++ b/src/test/projects/grpc-test/pom.xml
@@ -30,6 +30,11 @@
 
   <dependencies>
 	<!-- compile -->
+	  <dependency>
+		  <groupId>javax.annotation</groupId>
+		  <artifactId>javax.annotation-api</artifactId>
+		  <version>1.3.2</version>
+	  </dependency>
 	<dependency>
 		<groupId>com.google.protobuf</groupId>
 		<artifactId>protobuf-java</artifactId>

--- a/src/test/projects/grpc-test/pom.xml
+++ b/src/test/projects/grpc-test/pom.xml
@@ -24,6 +24,8 @@
   <properties>
 	<protobuf.version>3.6.0</protobuf.version>
 	<grpc.version>1.13.1</grpc.version>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/src/test/projects/import-test/pom.xml
+++ b/src/test/projects/import-test/pom.xml
@@ -23,6 +23,8 @@
 
   <properties>
 	<protobuf.version>3.6.0</protobuf.version>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/src/test/projects/mvn-compile-test/pom.xml
+++ b/src/test/projects/mvn-compile-test/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.os72</groupId>
+  <artifactId>mvn-compile-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <licenses>
+	<license>
+	  <name>The Apache Software License, Version 2.0</name>
+	  <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+	  <distribution>repo</distribution>
+	</license>
+  </licenses>
+
+  <developers>
+	<developer>
+	  <id>os72</id>
+	  <name>Oliver Suciu</name>
+	</developer>
+  </developers>
+
+  <properties>
+	<protobuf.version>3.6.0</protobuf.version>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+	<!-- compile -->
+	<dependency>
+		<groupId>com.google.protobuf</groupId>
+		<artifactId>protobuf-java</artifactId>
+		<version>${protobuf.version}</version>
+	</dependency>
+  </dependencies>
+
+  <build>
+	<plugins>
+		<plugin>
+			<groupId>com.github.os72</groupId>
+			<artifactId>protoc-jar-maven-plugin</artifactId>
+			<version>${it-plugin.version}</version>
+			<executions>
+				<execution>
+					<id>1</id>
+					<phase>generate-sources</phase>
+					<goals>
+						<goal>run</goal>
+					</goals>
+					<configuration>
+						<protocVersion>${protobuf.version}</protocVersion>
+						<addProtoSources>all</addProtoSources>
+						<includeMavenTypes>direct</includeMavenTypes>
+						<compileMavenTypes>direct</compileMavenTypes>
+						<outputTargets>
+							<outputTarget>
+								<type>java</type>
+								<addSources>main</addSources>
+							</outputTarget>
+							<outputTarget>
+								<type>descriptor</type>
+								<addSources>none</addSources>
+								<outputDirectory>${project.build.directory}/classes</outputDirectory>
+							</outputTarget>
+						</outputTargets>
+					</configuration>
+				</execution>
+			</executions>
+		</plugin>
+	</plugins>
+  </build>
+
+</project>

--- a/src/test/projects/shading-test/pom.xml
+++ b/src/test/projects/shading-test/pom.xml
@@ -23,6 +23,8 @@
 
   <properties>
 	<protobuf.version>360</protobuf.version>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Hello! Thank you for making this plugin.

**Proposed change**: new option `compileMavenTypes` that, when enabled, compiles the `.proto` files contained in the project's Maven dependencies.

Similarly to `includeMavenTypes`, it can be off (`none`), compile only direct dependencies (`direct`), or compile transitive dependencies (`transitive`).

**Context**: we use jar files to ship our `proto` definitions. That way, each project can compile what they need, for the platform they have. This flag allows us to achieve this easily with Maven.

Some commits (b6fdf56, 9092957, 5580195) were needed to build this plugin on our infra (likely running Java 8 and a more recent version of maven). Happy to remove them if you don't think they belong here.