### PR TITLE
Mark the switch to java 1.6 in the compiled jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
 		  <artifactId>maven-compiler-plugin</artifactId>
 		  <version>3.0</version>
 		  <configuration>
-			<source>1.5</source>
-			<target>1.5</target>
+			<source>1.6</source>
+			<target>1.6</target>
 		  </configuration>
 		</plugin>
 		<plugin>


### PR DESCRIPTION
My IDE warned me that certain methods introduced in java 6 were used (`String.isEmpty` for example), while the pom still targeted 1.5. If you would actually try to run this jar with java 5, you would get load time errors I expect.

Due to the age of java 5 and java 6, I thought it wouldn't be a problem to switch this, as I think the chances of someone still being on a java 5 jre are quite low, and it won't work anyway as I understand it.