### PR TITLE
Regenerate if missing an output directory.

### DIFF
--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -324,6 +324,8 @@ public class ProtocJarMojo extends AbstractMojo
 			target.outputOptions = outputOptions;
 			outputTargets = new OutputTarget[] {target};
 		}
+
+		boolean missingOutputDirectory = false;
 		
 		for (OutputTarget target : outputTargets) {
 			target.addSources = target.addSources.toLowerCase().trim();
@@ -337,9 +339,15 @@ public class ProtocJarMojo extends AbstractMojo
 			if (target.outputDirectorySuffix != null) {
 				target.outputDirectory = new File(target.outputDirectory, target.outputDirectorySuffix);
 			}
+
+			String[] outputFiles = target.outputDirectory.list();
+
+			if(outputFiles == null || outputFiles.length == 0) {
+				missingOutputDirectory = true;
+			}
 		}
 		
-		if (!optimizeCodegen) {
+		if (!optimizeCodegen || missingOutputDirectory) {
 			performProtoCompilation(true);
 			return;
 		}


### PR DESCRIPTION
Sometimes the generated sources will be manually deleted, either intentionally or by mistake.  optimizeCodegen will not detect this scenario.

This will detect if an output directory is missing and force protobuf to generate the source code.