### PR TITLE
Allow specifying additional compiler arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.os72</groupId>
   <artifactId>protoc-jar-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>3.11.4</version>
+  <version>3.11.5-SNAPSHOT</version>
   <name>protoc-jar-maven-plugin</name>
   <url>https://github.com/os72/protoc-jar-maven-plugin</url>
   <description>Protocol Buffers codegen plugin - based on protoc-jar executable JAR</description>

--- a/src/main/java/com/github/os72/protocjar/maven/OutputTarget.java
+++ b/src/main/java/com/github/os72/protocjar/maven/OutputTarget.java
@@ -16,6 +16,7 @@
 package com.github.os72.protocjar.maven;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Specifies output target
@@ -100,7 +101,14 @@ public class OutputTarget
      */
 	String outputOptions;
 
+	/**
+	 * Additional compiler arguments.
+	 *
+	 * @parameter property="additionalArguments"
+	 */
+	List<String> additionalArguments;
+
 	public String toString() {
-		return type + ": " + outputDirectory + " (add: " + addSources + ", clean: " + cleanOutputFolder + ", plugin: " + pluginPath + ", outputOptions: " + outputOptions + ")";
+		return type + ": " + outputDirectory + " (add: " + addSources + ", clean: " + cleanOutputFolder + ", plugin: " + pluginPath + ", outputOptions: " + outputOptions + ", additionalArguments: " + additionalArguments + ")";
 	}
 }


### PR DESCRIPTION
The protoc compiler introduces new features from time to time and currently there is no way to use those features until support is added to this plugin.

This change allows one to specify additional compiler arguments, which allows for enabling new and experimental features of the protoc compiler, e.g. --experimental_allow_proto3_optional.