### PR TITLE
added proto3Optional feature support

### DIFF
--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -158,6 +158,15 @@ public class ProtocJarMojo extends AbstractMojo
 	private boolean includeImports;
 
 	/**
+	 * Specifies whether to enable [experimental] proto3 optional feature.
+	 * Options: "true", "false" (default: "false")
+	 * <p>
+	 *
+	 * @parameter property="proto3Optional" default-value="false"
+	 */
+	private boolean proto3Optional;
+
+	/**
 	 * If this parameter is set to "true" output folder is cleaned prior to the
 	 * build. This will not let old and new classes coexist after package or
 	 * class rename in your IDE cache or after non-clean rebuild. Set this to
@@ -731,6 +740,10 @@ public class ProtocJarMojo extends AbstractMojo
 			}
 			else {
 				cmd.add("--" + type + "_out=" + outputDir);
+			}
+
+			if (proto3Optional) {
+				cmd.add("--experimental_allow_proto3_optional");
 			}
 
 			if (pluginPath != null) {


### PR DESCRIPTION
The optional feature was present in proto2. In proto3, this is included experimentally and requires a flag during protoc invocation.
Reference 1: https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0-rc1
Reference 2: https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md