### PR TITLE
fix: set default outputDirectorySuffix to protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Binaries
 
 Documentation: see http://os72.github.io/protoc-jar-maven-plugin/, in particular [run-mojo](http://os72.github.io/protoc-jar-maven-plugin/run-mojo.html)
 
-Sample usage - compile in main cycle into `target/generated-sources`, add generated sources to project, use default `protoc` version and default `src/main/protobuf` source folder:
+Sample usage - compile in main cycle into `target/generated-sources/protobuf`, add generated sources to project, use default `protoc` version and default `src/main/protobuf` source folder:
 ```xml
 <plugin>
 	<groupId>com.github.os72</groupId>
@@ -56,7 +56,7 @@ Sample usage - compile in main cycle into `target/generated-sources`, add genera
 </plugin>
 ```
 
-Sample usage - compile in main cycle into `target/generated-sources`, add generated sources to project, add all .proto sources to generated jar, include .proto files from direct maven dependencies, include additional imports:
+Sample usage - compile in main cycle into `target/generated-sources/protobuf`, add generated sources to project, add all .proto sources to generated jar, include .proto files from direct maven dependencies, include additional imports:
 ```xml
 <plugin>
 	<groupId>com.github.os72</groupId>

--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -202,7 +202,8 @@ public class ProtocJarMojo extends AbstractMojo
 	private File outputDirectory;
 
 	/**
-	 * If this parameter is set, append its value to the {@link #outputDirectory} path
+	 * If this parameter is set, append its value to the {@link #outputDirectory} path. Defaults to "protobuf".
+	 *
 	 * For example, value "protobuf" will set output directory to
 	 * "${project.build.directory}/generated-sources/protobuf" or
 	 * "${project.build.directory}/generated-test-sources/protobuf"
@@ -345,11 +346,12 @@ public class ProtocJarMojo extends AbstractMojo
 				String subdir = "generated-" + ("test".equals(target.addSources) ? "test-" : "") + "sources";
 				target.outputDirectory = new File(project.getBuild().getDirectory() + File.separator + subdir + File.separator);
 			}
-			
-			if (target.outputDirectorySuffix != null) {
-				target.outputDirectory = new File(target.outputDirectory, target.outputDirectorySuffix);
+
+			if (target.outputDirectorySuffix == null) {
+				target.outputDirectorySuffix = "protobuf";
 			}
-			
+
+			target.outputDirectory = new File(target.outputDirectory, target.outputDirectorySuffix);
 			String[] outputFiles = target.outputDirectory.list();
 			if (outputFiles == null || outputFiles.length == 0) {
 				missingOutputDirectory = true;


### PR DESCRIPTION
this sets the default `outputDirectorySuffix` to `protobuf`, causing the `.class` files to be in `target/generated-sources/protobuf`.

The reason for this is that most IDEs (or, at least intellij and if my memory is not failing me, eclipse) automatically adds anything on `target/generated/sources/<something>` to its sources. Without the `protobuf` dir, the first folder will be the first part of the package name (e.g. `com`), which breaks everything.