### PR TITLE
(#108) handle Pom projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.os72</groupId>
   <artifactId>protoc-jar-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>3.11.4</version>
+  <version>3.12.0</version>
   <name>protoc-jar-maven-plugin</name>
   <url>https://github.com/os72/protoc-jar-maven-plugin</url>
   <description>Protocol Buffers codegen plugin - based on protoc-jar executable JAR</description>

--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -171,6 +171,15 @@ public class ProtocJarMojo extends AbstractMojo
 	private boolean cleanOutputFolder;
 
 	/**
+	 * If this value is set to true, Maven projects with the packaging type POM will be exempted from the plugin run.
+	 *
+	 * Set this to false if you're using a monorepo and need to execute non-Java code generation in the parent project(s) as well.
+	 *
+	 * @parameter property="ignorePomPackaging" default-value="true"
+	 */
+	private boolean ignorePomPackaging;
+
+	/**
 	 * Path to the protoc plugin that generates code for the specified {@link #type}.
 	 * <p>
 	 * Ignored when {@code <outputTargets>} is given
@@ -317,11 +326,15 @@ public class ProtocJarMojo extends AbstractMojo
 	private File tempRoot = null;
 
 	public void execute() throws MojoExecutionException {
-		if (project.getPackaging() != null && "pom".equals(project.getPackaging().toLowerCase())) {
-			getLog().info("Skipping 'pom' packaged project");
-			return;
+		if (ignorePomPackaging){
+			if (project.getPackaging() != null && "pom".equals(project.getPackaging().toLowerCase())) {
+				getLog().info("Skipping 'pom' packaged project");
+				return;
+			}
+		} else {
+			getLog().info("'pom' skipping is suppressed at the user's request...");
 		}
-		
+
 		if (outputTargets == null || outputTargets.length == 0) {
 			OutputTarget target = new OutputTarget();
 			target.type = type;


### PR DESCRIPTION
This PR adds a new property, `ignorePomPackaging`, defaulting to `true` to maintain backwards compatibility. If set to false by the user, the plugin will not skip projects with the packaging `pom`, making it useful for handling monorepo-style structures, where the outer Java project is also host to other, non-Java folders that need the results of the protobuffer compilation.

While I expect this to be a little-used switch, I feel its implementation will add a dimension of usefulness to the plugin, at no cost to existing users.