### PR TITLE
get protoc version if include std types requested

### DIFF
--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -381,7 +381,7 @@ public class ProtocJarMojo extends AbstractMojo
 	}
 
 	private void performProtoCompilation(boolean doCodegen) throws MojoExecutionException {
-		if (doCodegen) prepareProtoc();
+		if (doCodegen || includeStdTypes) prepareProtoc();
 		
 		// even if doCodegen == false, we still extract extra includes/inputs because addProtoSources might be requested
 		// this could be optimized further


### PR DESCRIPTION
if include is requested and recompilation is happening this leads to crash because protocVersion is empty, in other words it is now know which version of std types to extract