### PR TITLE
Favor repositorySystemSession

### DIFF
--- a/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
+++ b/src/main/java/com/github/os72/protocjar/maven/ProtocJarMojo.java
@@ -292,11 +292,11 @@ public class ProtocJarMojo extends AbstractMojo
 	private MavenProject project;
 
 	/** 
-	 * @parameter default-value="${localRepository}" 
+	 * @parameter default-value="${repositorySystemSession}" 
 	 * @readonly
 	 * @required
 	 */
-	private ArtifactRepository localRepository;
+	private ArtifactRepository repositorySystemSession;
 
 	/** 
 	 * @parameter default-value="${project.remoteArtifactRepositories}" 
@@ -760,7 +760,7 @@ public class ProtocJarMojo extends AbstractMojo
 			getLog().info("Resolving artifact: " + artifactSpec + ", platform: " + platform);
 			String[] as = parseArtifactSpec(artifactSpec, platform);
 			Artifact artifact = artifactFactory.createDependencyArtifact(as[0], as[1], VersionRange.createFromVersionSpec(as[2]), as[3], as[4], Artifact.SCOPE_RUNTIME);
-			artifactResolver.resolve(artifact, remoteRepositories, localRepository);
+			artifactResolver.resolve(artifact, remoteRepositories, repositorySystemSession);
 			
 			File tempFile = File.createTempFile(as[1], "."+as[3], dir);
 			copyFile(artifact.getFile(), tempFile);


### PR DESCRIPTION
I have observed the following warning:

> [INFO] --- protoc-jar:3.11.4:run (default) @ project-foo ---
[WARNING] Parameter ‘localRepository’ is deprecated core expression; Avoid use of ArtifactRepository type. If you need access to local repository, switch to ‘${repositorySystemSession}’ expression and get LRM from it instead.

When using maven version:

> ❯ mvn --version
Apache Maven 3.9.1 (2e178502fcdbffc201671fb2537d0cb4b4cc58f8)
Java version: 17.0.7, vendor: Amazon.com Inc., runtime: /Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home
OS name: "mac os x", version: "13.3.1", arch: "x86_64", family: "mac"

--

I wonder if this change would address the above warning. I am not sure yet, still I leave a draft PR here open for comments and thoughts..